### PR TITLE
Fixing SQL error with default node state

### DIFF
--- a/modules/mysensor/mysensor.class.php
+++ b/modules/mysensor/mysensor.class.php
@@ -1256,7 +1256,7 @@ class mysensor extends module {
 		$sqlQuery = "CREATE TABLE IF NOT EXISTS `msnodestate`
                (`GID` int(10) NOT NULL DEFAULT 1,
 				`NID` int(10) NOT NULL,
-				`State` varchar(32) NOT NULL,
+				`State` varchar(32) NULL DEFAULT NULL,
 				`last` BIGINT NOT NULL,
 			   PRIMARY KEY (`NID`)
                ) ENGINE = MEMORY DEFAULT CHARSET=utf8;";


### PR DESCRIPTION
В строке 1219 `mysensor.class.php` возможна вставка в таблицу *msnodestate* без указания поля state:
https://github.com/Shagrat2/majordomo-mysensor/blob/510a0ad9db765801a470cee7416438dd1dfc46da/modules/mysensor/mysensor.class.php#L1219

при этом поле в базе объявлено как not null. В результате получаем ошибки вроде

> 1364: Field 'State' doesn't have a default value
> INSERT INTO msnodestate (GID,NID,last) VALUES (1,6,'1562937134' ) ON DUPLICATE KEY UPDATE last='1562937134';

и узел не обновляется. Изменил определение столбца для принятия NULL.
